### PR TITLE
TASK-1794166: Downgrade used XCode to 16.4

### DIFF
--- a/.github/actions/build-ios/action.yml
+++ b/.github/actions/build-ios/action.yml
@@ -11,6 +11,10 @@ runs:
       shell: bash
       run: brew install esbuild
 
+    - name: Select specific XCode version
+      shell: bash
+      run: sudo xcode-select -s "/Applications/Xcode_16.4.app"
+
     - name: Build .xcframework
       shell: bash
       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Install esbuild
         run: brew install esbuild
 
+      - name: Select specific XCode version
+        run: sudo xcode-select -s "/Applications/Xcode_16.4.app"
+
       - name: Create new test simulator
         run: |
           xcodebuild -version
@@ -95,7 +98,7 @@ jobs:
           echo "Deleting simulator SDKTestSimulator (if exists)"
           xcrun simctl delete SDKTestSimulator || true
           echo "Creating new SDKTestSimulator"
-          xcrun simctl create SDKTestSimulator com.apple.CoreSimulator.SimDeviceType.iPhone-16 com.apple.CoreSimulator.SimRuntime.iOS-18-2 | tee simulator.id
+          xcrun simctl create SDKTestSimulator com.apple.CoreSimulator.SimDeviceType.iPhone-16 com.apple.CoreSimulator.SimRuntime.iOS-18-5 | tee simulator.id
 
       - name: iOS sample application UI tests
         run: |


### PR DESCRIPTION
Downgrade/pin used Xcode Version to 16.4, to avoid issues when Mac OS image is updated by the Github team with incompatible default Xcode version (as it was with Xcode 26)