### PR TITLE
ISSUE-136828: [SwiftUI] Do not use NSAttributedString to strip HTML tags.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -118,7 +118,15 @@ jobs:
           set -o pipefail
           rm -rf build || true
           mkdir build
-          xcodebuild -quiet -project samples/swiftui-components-app/UITest/UITest.xcodeproj -scheme UITest -destination "platform=iOS Simulator,id=$(cat simulator.id)" -resultBundlePath ./build/iOSTests.xcresult -retry-tests-on-failure -test-iterations 2 -parallel-testing-enabled NO test 2>&1
+          xcodebuild \
+            -project samples/swiftui-components-app/UITest/UITest.xcodeproj \
+            -scheme UITest \
+            -destination "platform=iOS Simulator,id=$(cat simulator.id)" \
+            -resultBundlePath ./build/iOSTests.xcresult \
+            -retry-tests-on-failure \
+            -test-iterations 2 \
+            -parallel-testing-enabled NO \
+             test 2>&1 | xcpretty && exit ${PIPESTATUS[0]}
       - name: Upload test artifacts for failures
         if: failure()
         uses: actions/upload-artifact@v4

--- a/samples/swiftui-components-app/UITest/UI Tests/TestCaseProcessing.swift
+++ b/samples/swiftui-components-app/UITest/UI Tests/TestCaseProcessing.swift
@@ -7,6 +7,9 @@ final class TestCaseProcessing: MockedAppTestCase {
         verifyMainScreen()
         tapCreateButton("SDKTesting")
 
+        // Verify that html tags are removed from Step instructions.
+        app.staticTexts["Step instructions"].assertExists()
+
         fillTextField(0, "Name", "Jan", dismissSlidingDialog: true)
         fillTextField(1, "Surname", "Kowalski")
         // Second text field has also placeholder text set

--- a/samples/swiftui-components-app/UITest/Unit Tests/UtilsTests.swift
+++ b/samples/swiftui-components-app/UITest/Unit Tests/UtilsTests.swift
@@ -37,6 +37,20 @@ extension UtilsTests {
             XCTAssertEqual(expect, input.formattedToDecimalPlaces(decimal))
         }
     }
+
+    func testHtmlStripping() {
+        let expectations: [(String, String)] = [
+            // expected, input
+            ("Paragraph", "<p>Paragraph</p>"),
+            ("Link inside the div", "<div><a href=\"#\">Link</a> inside the div</div>"),
+            ("Deprecated font tag.", "Deprecated <font color=\"red\" size=10>font</font> tag."),
+            ("Styled div tag", "Styled <div style=\"font-size:11px;color: red;\">div</div> tag")
+        ]
+
+        for (expect, input) in expectations {
+            XCTAssertEqual(expect, input.strippingHtmlTags)
+        }
+    }
 }
 
 // MARK: - Bundle Utils

--- a/samples/swiftui-components-app/swiftui-components-app/SDKSupport/UI/Containers/DefaultFormView.swift
+++ b/samples/swiftui-components-app/swiftui-components-app/SDKSupport/UI/Containers/DefaultFormView.swift
@@ -10,25 +10,12 @@ struct DefaultFormView: View {
 
     var body: some View {
         VStack {
-            if !state.component.instructions.stripHTML.isEmpty {
-                Text(state.component.instructions.stripHTML)
+            if !state.component.instructions.strippingHtmlTags.isEmpty {
+                Text(state.component.instructions.strippingHtmlTags)
             }
             ForEach(state.component.children, id: \.context.id) { child in
                 child.renderView()
             }
         }
-    }
-}
-
-extension String {
-    fileprivate var stripHTML: String {
-        (try? NSAttributedString(
-            data: Data(self.utf8),
-            options: [
-                .documentType: NSAttributedString.DocumentType.html,
-                .characterEncoding: String.Encoding.utf8.rawValue
-            ],
-            documentAttributes: nil
-        ))?.string ?? ""
     }
 }

--- a/samples/swiftui-components-app/swiftui-components-app/SDKSupport/Utils/String+Utils.swift
+++ b/samples/swiftui-components-app/swiftui-components-app/SDKSupport/Utils/String+Utils.swift
@@ -15,4 +15,8 @@ extension String {
         }
         return filtered
     }
+
+    var strippingHtmlTags: String {
+        replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression, range: nil)
+    }
 }


### PR DESCRIPTION
The issue is not straightforward. The `Modifying state during view update` error log call stack originates from the `stripHTML` extension getter. 

The `stripHTML` uses `NSAttributedString` to parse html and take parsed string from it. It is looks like the `NSAttributedString` uses underlying webkit process to parse html and therefore gives execution time to JS context. This gives time to JS side to dispatch bridged event from webkit-based engine, causing view update during executing view update which leads to the error log:

<img width="345" height="607" alt="stripHtml" src="https://github.com/user-attachments/assets/ddb299ae-ba14-4cd7-960d-c39619bf3937" />

Proposed solution is to not use `NSAttrubutedString` to remove HTML tags and use simple regex instead. This will be safer and faster approach. This will not work properly with more complicated cases (like improper html, advanced entities, etc) but I think this is good enough for the sample app for now.