### PR TITLE
ENHANCEMENT-473: add SemanticLink component support and fix DataReference duplicate refresh

### DIFF
--- a/core/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/core/components/ComponentRegistry.kt
+++ b/core/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/core/components/ComponentRegistry.kt
@@ -28,6 +28,7 @@ import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.Phone
 import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.RadioButtons
 import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.Region
 import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.RichText
+import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.SemanticLink
 import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.RootContainer
 import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.SimpleComboBox
 import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.SimpleTable
@@ -71,6 +72,7 @@ import com.pega.constellation.sdk.kmp.core.components.fields.PhoneComponent
 import com.pega.constellation.sdk.kmp.core.components.fields.RadioButtonsComponent
 import com.pega.constellation.sdk.kmp.core.components.fields.RichTextComponent
 import com.pega.constellation.sdk.kmp.core.components.fields.SimpleComboBoxComponent
+import com.pega.constellation.sdk.kmp.core.components.fields.SemanticLinkComponent
 import com.pega.constellation.sdk.kmp.core.components.fields.TextAreaComponent
 import com.pega.constellation.sdk.kmp.core.components.fields.TextInputComponent
 import com.pega.constellation.sdk.kmp.core.components.fields.TimeComponent
@@ -118,6 +120,7 @@ object ComponentRegistry {
         Def(RadioButtons) { RadioButtonsComponent(it) },
         Def(Region) { RegionComponent(it) },
         Def(RootContainer) { RootContainerComponent(it) },
+        Def(SemanticLink) { SemanticLinkComponent(it) },
         Def(SimpleTable) { SimpleTableComponent(it) },
         Def(SimpleTableManual) { SimpleTableManualComponent(it) },
         Def(SimpleTableSelect) { SimpleTableSelectComponent(it) },

--- a/core/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/core/components/ComponentTypes.kt
+++ b/core/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/core/components/ComponentTypes.kt
@@ -42,6 +42,7 @@ object ComponentTypes {
     val RadioButtons = ComponentType("RadioButtons")
     val RichText = ComponentType("RichText")
     val SimpleComboBox = ComponentType("SimpleComboBox")
+    val SemanticLink = ComponentType("SemanticLink")
     val TextArea = ComponentType("TextArea")
     val TextInput = ComponentType("TextInput")
     val Time = ComponentType("Time")

--- a/core/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/core/components/fields/SemanticLink.kt
+++ b/core/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/core/components/fields/SemanticLink.kt
@@ -1,0 +1,28 @@
+package com.pega.constellation.sdk.kmp.core.components.fields
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.pega.constellation.sdk.kmp.core.api.BaseComponent
+import com.pega.constellation.sdk.kmp.core.api.ComponentContext
+import com.pega.constellation.sdk.kmp.core.api.HideableComponent
+import com.pega.constellation.sdk.kmp.core.components.getString
+import com.pega.constellation.sdk.kmp.core.components.optBoolean
+import kotlinx.serialization.json.JsonObject
+
+class SemanticLinkComponent(context: ComponentContext) : BaseComponent(context), HideableComponent {
+    var value: String by mutableStateOf("")
+        private set
+    var label: String by mutableStateOf("")
+        private set
+    override var visible: Boolean by mutableStateOf(false)
+        private set
+
+    override fun applyProps(props: JsonObject) {
+        with(props) {
+            value = getString("value")
+            label = getString("label")
+            visible = optBoolean("visible", true)
+        }
+    }
+}

--- a/samples/android-cmp-app/src/androidInstrumentedTest/kotlin/com/pega/constellation/sdk/kmp/samples/androidcmpapp/test/cases/DataRefSemanticLinkTest.kt
+++ b/samples/android-cmp-app/src/androidInstrumentedTest/kotlin/com/pega/constellation/sdk/kmp/samples/androidcmpapp/test/cases/DataRefSemanticLinkTest.kt
@@ -1,0 +1,41 @@
+package com.pega.constellation.sdk.kmp.samples.androidcmpapp.test.cases
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.pega.constellation.sdk.kmp.samples.androidcmpapp.test.ComposeTest
+import com.pega.constellation.sdk.kmp.samples.androidcmpapp.test.runAndroidTest
+import com.pega.constellation.sdk.kmp.samples.androidcmpapp.test.waitForNode
+import com.pega.constellation.sdk.kmp.samples.androidcmpapp.test.waitForNodes
+import com.pega.constellation.sdk.kmp.test.mock.PegaVersion
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class DataRefSemanticLinkTest : ComposeTest(PegaVersion.v25_1) {
+
+    @Test
+    fun test_data_reference_form_and_semantic_link() = runAndroidTest {
+        setupApp("OI1OYV-Marco2-Work-DataReferenceTest-FieldOnly")
+
+        // create case
+        onNodeWithText("New Service").performClick()
+
+        // Step 1: verify DataReference form with Dropdown appears
+        waitForNode("DataReferenceSingleCars")
+
+        // Select "Focus" from the dropdown
+        onNodeWithText("DataReferenceSingleCars").performClick()
+        waitForNode("Focus")
+        onNodeWithText("Focus").performClick()
+
+        // Verify refresh populated the subview with Brand and Model
+        waitForNodes("Focus", 2)
+        waitForNode("Ford")
+
+        // Submit step 1 → step 2 loads with SemanticLink
+        onNodeWithText("Next").performClick()
+
+        // Step 2: verify SemanticLink renders the selected car model
+        waitForNode("Focus")
+    }
+}

--- a/scripts/dxcomponents/components/containers/templates/data-reference.component.js
+++ b/scripts/dxcomponents/components/containers/templates/data-reference.component.js
@@ -279,6 +279,8 @@ export class DataReferenceComponent extends ContainerBaseComponent {
     #handleSelection(event) {
         const caseKey = this.pConn.getCaseInfo().getKey();
         const refreshOptions = { autoDetectRefresh: true };
+        // AutoComplete sets value on event.id whereas Dropdown sets it on event.target.value
+        const selectionValue = event?.id || event?.target?.value;
 
         const children = this.pConn.getRawMetadata()?.children;
         if (children?.length > 0 && children[0].config?.value) {
@@ -286,19 +288,29 @@ export class DataReferenceComponent extends ContainerBaseComponent {
             refreshOptions.classID = this.pConn.getRawMetadata().classID;
         }
 
+        // Skip manual refreshCaseView for picklist-based children (Dropdown, AutoComplete, Checkbox)
+        // as they don't have an associated view configured and trigger refresh automatically
+        const hasAssociatedViewConfigured = this.rawViewMetadata.children?.[1]?.children?.length;
+
         if (this.canBeChangedInReviewMode && this.pConn.getValue("__currentPageTabViewName")) {
             this.pConn
                 .getActionsApi()
-                .refreshCaseView(caseKey, this.pConn.getValue("__currentPageTabViewName"), "", refreshOptions);
+                .refreshCaseView(caseKey, this.pConn.getValue("__currentPageTabViewName"), "", refreshOptions)
+                ?.catch((error) => {
+                    console.warn(`${TAG} refreshCaseView failed (review mode)`, error?.name, error?.message);
+                });
             PCore.getDeferLoadManager().refreshActiveComponents(this.pConn.getContextName());
-        } else {
+        } else if (hasAssociatedViewConfigured) {
             const pgRef = this.pConn.getPageReference().replace("caseInfo.content", "");
-            this.pConn.getActionsApi().refreshCaseView(caseKey, this.viewName, pgRef, refreshOptions);
+            this.pConn
+                .getActionsApi()
+                .refreshCaseView(caseKey, this.viewName, pgRef, refreshOptions)
+                ?.catch((error) => {
+                    console.warn(`${TAG} refreshCaseView failed`, error?.name, error?.message);
+                });
         }
 
-        // AutoComplete sets value on event.id whereas Dropdown sets it on event.target.value
-        const propValue = event?.id || event?.target?.value;
-        if (propValue && this.canBeChangedInReviewMode && this.isDisplayModeEnabled) {
+        if (selectionValue && this.canBeChangedInReviewMode && this.isDisplayModeEnabled) {
             PCore.getDataApiUtils()
                 .getCaseEditLock(caseKey, "")
                 .then((caseResponse) => {
@@ -317,7 +329,7 @@ export class DataReferenceComponent extends ContainerBaseComponent {
                     const propArr = this.propName.split(".");
                     propArr.forEach((element, idx) => {
                         if (idx + 1 === propArr.length) {
-                            curr[element] = propValue;
+                            curr[element] = selectionValue;
                         } else {
                             curr[element] = {};
                             curr = curr[element];

--- a/scripts/dxcomponents/components/fields/semantic-link.component.js
+++ b/scripts/dxcomponents/components/fields/semantic-link.component.js
@@ -1,0 +1,47 @@
+import { BaseComponent } from "../base.component.js";
+
+export class SemanticLinkComponent extends BaseComponent {
+    jsComponentPConnectData = {};
+
+    props = {
+        value: "",
+        label: "",
+        visible: true,
+    };
+
+    init() {
+        this.jsComponentPConnectData = this.jsComponentPConnect.registerAndSubscribeComponent(
+            this,
+            this.checkAndUpdate
+        );
+        this.componentsManager.onComponentAdded(this);
+        this.checkAndUpdate();
+    }
+
+    destroy() {
+        super.destroy();
+        this.jsComponentPConnectData.unsubscribeFn?.();
+        this.componentsManager.onComponentRemoved(this);
+    }
+
+    update(pConn) {
+        if (this.pConn !== pConn) {
+            this.pConn = pConn;
+            this.checkAndUpdate();
+        }
+    }
+
+    checkAndUpdate() {
+        if (this.jsComponentPConnect.shouldComponentUpdate(this)) {
+            this.#updateSelf();
+        }
+    }
+
+    #updateSelf() {
+        const configProps = this.pConn.resolveConfigProps(this.pConn.getConfigProps());
+        this.props.label = configProps.label ?? "";
+        this.props.value = configProps.text ?? configProps.value ?? "";
+        this.props.visible = this.utils.getBooleanValue(configProps.visibility ?? this.props.visible);
+        this.componentsManager.onComponentPropsUpdate(this);
+    }
+}

--- a/scripts/dxcomponents/mappings/sdk-pega-component-map.js
+++ b/scripts/dxcomponents/mappings/sdk-pega-component-map.js
@@ -34,7 +34,7 @@ import { IntegerComponent } from "../components/fields/integer.component.js";
 // import { PercentageComponent } from './_components/field/percentage/percentage.component';
 import { PhoneComponent } from "../components/fields/phone.component.js";
 import { RadioButtonsComponent } from "../components/fields/radio-buttons.component.js";
-// import { SemanticLinkComponent } from './_components/field/semantic-link/semantic-link.component';
+import { SemanticLinkComponent } from "../components/fields/semantic-link.component.js";
 import { TextAreaComponent } from "../components/fields/text-area.component.js";
 // import { TextComponent } from './_components/field/text/text.component';
 // import { TextContentComponent } from './_components/field/text-content/text-content.component';
@@ -219,6 +219,7 @@ const pegaSdkComponentMap = {
     // ScalarList: ScalarListComponent,
     // SemanticLink: SemanticLinkComponent,
     SimpleComboBox: SimpleComboBoxComponent,
+    SemanticLink: SemanticLinkComponent,
     SimpleTable: SimpleTableComponent,
     SimpleTableManual: SimpleTableManualComponent,
     SimpleTableSelect: SimpleTableSelectComponent,

--- a/test/src/commonMain/composeResources/files/responses/dx/assignments/DataRefSemanticLinkTest-1-Create.json
+++ b/test/src/commonMain/composeResources/files/responses/dx/assignments/DataRefSemanticLinkTest-1-Create.json
@@ -1,0 +1,378 @@
+{
+	"data": {
+		"caseInfo": {
+			"caseTypeID": "OI1OYV-Marco2-Work-DataReferenceTest",
+			"owner": "user@marco",
+			"availableActions": [{
+				"name": "Edit details",
+				"links": {
+					"open": {
+						"rel": "self",
+						"href": "/cases/OI1OYV-MARCO2-WORK D-12038/actions/pyUpdateCaseDetails",
+						"type": "GET",
+						"title": "Get case action details"
+					}
+				},
+				"ID": "pyUpdateCaseDetails",
+				"type": "Case"
+			}, {
+				"name": "Change stage",
+				"links": {
+					"open": {
+						"rel": "self",
+						"href": "/cases/OI1OYV-MARCO2-WORK D-12038/actions/pyChangeStage",
+						"type": "GET",
+						"title": "Get case action details"
+					}
+				},
+				"ID": "pyChangeStage",
+				"type": "Case"
+			}],
+			"associations": {
+				"follows": false
+			},
+			"lastUpdatedBy": "user@marco",
+			"assignments": [{
+				"instructions": "",
+				"canPerform": "true",
+				"assigneeInfo": {
+					"name": "Administrator",
+					"ID": "user@marco",
+					"type": "worklist"
+				},
+				"processID": "CreateForm_Default",
+				"createTime": "2026-04-22T09:20:12.463Z",
+				"urgency": 10,
+				"processName": "Create",
+				"isMultiStep": "true",
+				"name": "step2",
+				"context": "",
+				"links": {
+					"open": {
+						"rel": "self",
+						"href": "/assignments/ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT",
+						"type": "GET",
+						"title": "Get assignment details"
+					}
+				},
+				"ID": "ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT",
+				"actions": [{
+					"name": "step2",
+					"links": {
+						"submit": {
+							"rel": "self",
+							"href": "/assignments/ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT/actions/Step2_2",
+							"type": "PATCH",
+							"title": "Submit assignment action "
+						},
+						"save": {
+							"rel": "self",
+							"href": "/assignments/ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT/actions/Step2_2/save",
+							"type": "PATCH",
+							"title": "Save assignment action "
+						},
+						"open": {
+							"rel": "self",
+							"href": "/assignments/ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT/actions/Step2_2",
+							"type": "GET",
+							"title": "Get assignment action details"
+						}
+					},
+					"ID": "Step2_2",
+					"type": "FlowAction"
+				}]
+			}],
+			"hasNewAttachments": false,
+			"businessID": "D-12038",
+			"sla": {
+				"goal": "",
+				"deadline": ""
+			},
+			"WidgetsToRefresh": ["TaskList"],
+			"caseTypeName": "DataReferenceTest",
+			"urgency": 10,
+			"createTime": "2026-04-22T09:16:54.661Z",
+			"createdBy": "user@marco",
+			"name": "DataReferenceTest",
+			"stages": [{
+				"entryTime": "2026-04-22T09:16:54.667Z",
+				"name": "Create",
+				"links": {
+					"open": {
+						"rel": "self",
+						"href": "/cases/OI1OYV-MARCO2-WORK D-12038/stages/PRIM0",
+						"type": "PUT",
+						"title": "Jump to this stage"
+					}
+				},
+				"visited_status": "active",
+				"ID": "PRIM0",
+				"type": "Primary",
+				"transitionType": "create"
+			}, {
+				"name": "stage2",
+				"links": {
+					"open": {
+						"rel": "self",
+						"href": "/cases/OI1OYV-MARCO2-WORK D-12038/stages/PRIM1",
+						"type": "PUT",
+						"title": "Jump to this stage"
+					}
+				},
+				"visited_status": "future",
+				"ID": "PRIM1",
+				"type": "Primary",
+				"transitionType": "manual"
+			}],
+			"ID": "OI1OYV-MARCO2-WORK D-12038",
+			"caseTypeIcon": "cmicons/pycase.svg",
+			"status": "New",
+			"stageID": "PRIM0",
+			"stageLabel": "Create",
+			"lastUpdateTime": "2026-04-22T09:20:12.467Z",
+			"content": {
+				"classID": "OI1OYV-Marco2-Work-DataReferenceTest",
+				"DataReferenceSingleCars": {
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"pyGUID": "909106bf-f108-4751-9357-8a628a01dc3f",
+					"Model": "Focus"
+				},
+				"pxObjClass": "OI1OYV-Marco2-Work-DataReferenceTest",
+				"pyLabel": "DataReferenceTest",
+				"pyID": "D-12038"
+			}
+		}
+	},
+	"uiResources": {
+		"resources": {
+			"views": {
+				"Step2_2": [{
+					"children": [{
+						"children": [{
+							"config": {
+								"authorContext": ".DataReferenceSingleCars",
+								"inheritedProps": [{
+									"prop": "label",
+									"value": "@FL .DataReferenceSingleCars"
+								}],
+								"name": "Step2_DataReferenceSingleCars",
+								"referenceType": "Data",
+								"ruleClass": "OI1OYV-Marco2-Work-DataReferenceTest",
+								"type": "view"
+							},
+							"type": "reference"
+						}],
+						"name": "Fields",
+						"type": "Region"
+					}],
+					"config": {
+						"NumCols": "2",
+						"localeReference": "@LR OI1OYV-MARCO2-WORK-DATAREFERENCETEST!VIEW!STEP2_2",
+						"ruleClass": "OI1OYV-Marco2-Work-DataReferenceTest",
+						"template": "DefaultForm"
+					},
+					"name": "Step2_2",
+					"type": "View",
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest"
+				}],
+				"Step2_DataReferenceSingleCars": [{
+					"children": [{
+						"config": {
+							"caseClass": "OI1OYV-Marco2-Data-Car",
+							"contextPage": "@P .DataReferenceSingleCars",
+							"label": "@L ",
+							"previewKey": "@P .DataReferenceSingleCars.pyGUID",
+							"referenceType": "data",
+							"text": "@P .DataReferenceSingleCars.Model"
+						},
+						"type": "SemanticLink"
+					}, {
+						"children": [],
+						"name": "Views",
+						"type": "Region"
+					}],
+					"config": {
+						"classKeys": [{
+							"name": "pyGUID"
+						}],
+						"contextClass": "OI1OYV-Marco2-Data-Car",
+						"displayAs": "readonly",
+						"localeReference": "@LR OI1OYV-MARCO2-WORK-DATAREFERENCETEST!VIEW!STEP2_DATAREFERENCESINGLECARS",
+						"mode": "readonly",
+						"name": "DataReferenceSingleCars",
+						"referenceList": "D_CarsList2",
+						"ruleClass": "OI1OYV-Marco2-Work-DataReferenceTest",
+						"selectionMode": "single",
+						"template": "DataReference"
+					},
+					"name": "Step2_DataReferenceSingleCars",
+					"type": "View",
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest"
+				}]
+			},
+			"datapages": {
+				"D_car": {
+					"parameters": [{
+						"name": "pyGUID",
+						"defaultValue": "",
+						"linkedField": "pyGUID"
+					}],
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"mode": "readonly",
+					"isSearchable": false,
+					"isQueryable": false,
+					"isAlternateKeyStorage": true,
+					"structure": "page"
+				},
+				"D_carSavable": {
+					"parameters": [{
+						"name": "pyGUID",
+						"defaultValue": "",
+						"linkedField": "pyGUID"
+					}],
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"mode": "editable",
+					"isSearchable": false,
+					"isQueryable": false,
+					"isAlternateKeyStorage": true,
+					"structure": "page"
+				}
+			},
+			"dataTypes": {
+				"OI1OYV-Marco2-Data-Car": {
+					"classKeys": ["pyGUID"],
+					"savableDataPage": "D_carSavable",
+					"lookupDataPage": "D_car",
+					"lookupDataPageInfo": {
+						"isAlternateKeyStorage": true,
+						"parameters": {
+							"pyGUID": "@P .pyGUID"
+						}
+					}
+				}
+			},
+			"fields": {
+				"pyGUID": [{
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"type": "Text",
+					"maxLength": 128,
+					"displayAs": "pxTextInput",
+					"definedOnClassID": "@baseclass",
+					"label": "Globally unique ID",
+					"isClassKey": true
+				}],
+				"DataReferenceSingleCars": [{
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest",
+					"type": "Page",
+					"dataRetrievalType": "refer",
+					"pageClass": "OI1OYV-Marco2-Data-Car",
+					"label": "DataReferenceSingleCars",
+					"datasource": {
+						"name": "D_car",
+						"parameters": {
+							"pyGUID": "@P .DataReferenceSingleCars.pyGUID"
+						}
+					}
+				}],
+				"Model": [{
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"type": "Text",
+					"maxLength": 256,
+					"displayAs": "pxTextInput",
+					"label": "model"
+				}],
+				"pyLabel": [{
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest",
+					"type": "Text",
+					"maxLength": 64,
+					"displayAs": "pxTextInput",
+					"definedOnClassID": "Work-",
+					"expectedLength": 60,
+					"label": "Label"
+				}],
+				"pyID": [{
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest",
+					"type": "Text",
+					"maxLength": 32,
+					"displayAs": "pxDisplayText",
+					"definedOnClassID": "Work-Cover-",
+					"expectedLength": 22,
+					"label": "Case ID",
+					"isClassKey": true
+				}]
+			}
+		},
+		"components": ["DefaultForm", "Region", "View", "SemanticLink", "DataReference"],
+		"localeReferences": ["OI1OYV-MARCO2-WORK-DATAREFERENCETEST!CASE!DATAREFERENCETEST"],
+		"root": {
+			"type": "reference",
+			"config": {
+				"type": "view",
+				"name": "Step2_2",
+				"context": "caseInfo.content"
+			}
+		},
+		"context_data": {},
+		"navigation": {
+			"template": "Horizontal",
+			"steps": [{
+				"allow_jump": true,
+				"name": "Create",
+				"actionID": "Create",
+				"visited_status": "success",
+				"links": {
+					"open": {
+						"rel": "self",
+						"href": "assignments/ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT/navigation_steps/AssignmentSF1",
+						"type": "PATCH",
+						"title": "Go to Create"
+					}
+				},
+				"ID": "AssignmentSF1"
+			}, {
+				"allow_jump": true,
+				"name": "step2",
+				"actionID": "Step2_2",
+				"visited_status": "current",
+				"ID": "AssignmentSF2"
+			}]
+		},
+		"actionButtons": {
+			"secondary": [{
+				"jsAction": "cancelAssignment",
+				"name": "Cancel",
+				"actionID": "cancel"
+			}, {
+				"jsAction": "navigateToStep",
+				"name": "Previous",
+				"actionID": "back",
+				"links": {
+					"open": {
+						"rel": "self",
+						"href": "assignments/ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT/navigation_steps/previous",
+						"type": "PATCH",
+						"title": "Go back to previous step"
+					}
+				}
+			}],
+			"main": [{
+				"jsAction": "finishAssignment",
+				"name": "Submit",
+				"actionID": "submit"
+			}]
+		}
+	},
+	"nextAssignmentInfo": {
+		"context": "self",
+		"className": "OI1OYV-Marco2-Work-DataReferenceTest",
+		"links": {
+			"open": {
+				"rel": "self",
+				"href": "/assignments/ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT",
+				"type": "GET",
+				"title": "Get assignment details"
+			}
+		},
+		"ID": "ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT"
+	}
+}

--- a/test/src/commonMain/composeResources/files/responses/dx/assignments/refresh/DataRefSemanticLinkTest-Create-Refresh.json
+++ b/test/src/commonMain/composeResources/files/responses/dx/assignments/refresh/DataRefSemanticLinkTest-Create-Refresh.json
@@ -1,0 +1,271 @@
+{
+	"data": {
+		"caseInfo": {
+			"content": {
+				"classID": "OI1OYV-Marco2-Work-DataReferenceTest",
+				"DataReferenceSingleCars": {
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"pyGUID": "909106bf-f108-4751-9357-8a628a01dc3f",
+					"Model": "Focus",
+					"Brand": "Ford"
+				}
+			}
+		}
+	},
+	"uiResources": {
+		"resources": {
+			"views": {
+				"Create": [{
+					"children": [{
+						"children": [{
+							"config": {
+								"authorContext": ".DataReferenceSingleCars",
+								"inheritedProps": [{
+									"prop": "label",
+									"value": "@FL .DataReferenceSingleCars"
+								}],
+								"name": "Create_DataReferenceSingleCars",
+								"referenceType": "Data",
+								"ruleClass": "OI1OYV-Marco2-Work-DataReferenceTest",
+								"type": "view"
+							},
+							"type": "reference"
+						}],
+						"name": "Fields",
+						"type": "Region"
+					}],
+					"config": {
+						"NumCols": "2",
+						"localeReference": "@LR OI1OYV-MARCO2-WORK-DATAREFERENCETEST!VIEW!CREATE",
+						"ruleClass": "OI1OYV-Marco2-Work-DataReferenceTest",
+						"template": "DefaultForm"
+					},
+					"name": "Create",
+					"type": "View",
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest"
+				}],
+				"Create_DataReferenceSingleCars": [{
+					"children": [{
+						"config": {
+							"columns": [{
+								"key": "true",
+								"setProperty": "Associated property",
+								"value": ".pyGUID"
+							}, {
+								"display": "true",
+								"primary": "true",
+								"useForSearch": true,
+								"value": ".Model"
+							}],
+							"contextPage": "@P .DataReferenceSingleCars",
+							"datasource": "D_CarsList2",
+							"deferDatasource": true,
+							"label": "@L ",
+							"labelOption": "custom",
+							"listType": "datapage",
+							"placeholder": "@L Select...",
+							"primaryField": "@P .DataReferenceSingleCars.Model",
+							"value": "@P .DataReferenceSingleCars.pyGUID"
+						},
+						"type": "Dropdown"
+					}, {
+						"children": [{
+							"config": {
+								"context": ".DataReferenceSingleCars",
+								"inheritedProps": [{
+									"prop": "showLabel",
+									"value": true
+								}, {
+									"prop": "label",
+									"value": "@L Create - EmbeddedDataCarSingle"
+								}],
+								"name": "Create_EmbeddedDataCarSingle",
+								"readOnly": true,
+								"ruleClass": "OI1OYV-Marco2-Data-Car",
+								"type": "view"
+							},
+							"type": "reference"
+						}],
+						"name": "Views",
+						"type": "Region"
+					}],
+					"config": {
+						"classKeys": [{
+							"name": "pyGUID"
+						}],
+						"contextClass": "OI1OYV-Marco2-Data-Car",
+						"displayAs": "dropdown",
+						"localeReference": "@LR OI1OYV-MARCO2-WORK-DATAREFERENCETEST!VIEW!CREATE_DATAREFERENCESINGLECARS",
+						"mode": "singleselect",
+						"name": "DataReferenceSingleCars",
+						"parameters": {
+							"brand": ""
+						},
+						"referenceList": "D_CarsList2",
+						"ruleClass": "OI1OYV-Marco2-Work-DataReferenceTest",
+						"selectionMode": "single",
+						"template": "DataReference"
+					},
+					"name": "Create_DataReferenceSingleCars",
+					"type": "View",
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest"
+				}],
+				"Create_EmbeddedDataCarSingle": [{
+					"children": [{
+						"children": [{
+							"config": {
+								"label": "@FL .Brand",
+								"labelOption": "default",
+								"value": "@P .Brand"
+							},
+							"type": "TextInput"
+						}, {
+							"config": {
+								"label": "@FL .Model",
+								"labelOption": "default",
+								"value": "@P .Model"
+							},
+							"type": "TextInput"
+						}, {
+							"config": {
+								"allowDecimals": true,
+								"alwaysShowISOCode": false,
+								"isoCodeSelection": "constant",
+								"label": "@FL .Price",
+								"labelOption": "default",
+								"value": "@P .Price",
+								"visibility": "@W pyIsMobileApp"
+							},
+							"type": "Currency"
+						}],
+						"name": "Fields",
+						"type": "Region"
+					}],
+					"config": {
+						"localeReference": "@LR OI1OYV-MARCO2-DATA-CAR!VIEW!CREATE_EMBEDDEDDATACARSINGLE",
+						"mode": "editable",
+						"ruleClass": "OI1OYV-Marco2-Data-Car",
+						"template": "DefaultForm"
+					},
+					"name": "Create_EmbeddedDataCarSingle",
+					"type": "View",
+					"classID": "OI1OYV-Marco2-Data-Car"
+				}]
+			},
+			"datapages": {
+				"D_car": {
+					"parameters": [{
+						"name": "pyGUID",
+						"defaultValue": "",
+						"linkedField": "pyGUID"
+					}],
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"mode": "readonly",
+					"isSearchable": false,
+					"isQueryable": false,
+					"isAlternateKeyStorage": true,
+					"structure": "page"
+				},
+				"D_CarsList2": {
+					"parameters": [{
+						"name": "brand",
+						"defaultValue": ""
+					}],
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"mode": "readonly",
+					"isSearchable": false,
+					"isQueryable": true,
+					"structure": "list",
+					"isWorkObject": false,
+					"isDataObject": true
+				},
+				"D_carSavable": {
+					"parameters": [{
+						"name": "pyGUID",
+						"defaultValue": "",
+						"linkedField": "pyGUID"
+					}],
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"mode": "editable",
+					"isSearchable": false,
+					"isQueryable": false,
+					"isAlternateKeyStorage": true,
+					"structure": "page"
+				}
+			},
+			"dataTypes": {
+				"OI1OYV-Marco2-Data-Car": {
+					"classKeys": ["pyGUID"],
+					"savableDataPage": "D_carSavable",
+					"lookupDataPage": "D_car",
+					"lookupDataPageInfo": {
+						"isAlternateKeyStorage": true,
+						"parameters": {
+							"pyGUID": "@P .pyGUID"
+						}
+					}
+				}
+			},
+			"fields": {
+				"pyGUID": [{
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"type": "Text",
+					"maxLength": 128,
+					"displayAs": "pxTextInput",
+					"definedOnClassID": "@baseclass",
+					"label": "Globally unique ID",
+					"isClassKey": true
+				}],
+				"DataReferenceSingleCars": [{
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest",
+					"type": "Page",
+					"dataRetrievalType": "refer",
+					"pageClass": "OI1OYV-Marco2-Data-Car",
+					"label": "DataReferenceSingleCars",
+					"datasource": {
+						"name": "D_car",
+						"parameters": {
+							"pyGUID": "@P .DataReferenceSingleCars.pyGUID"
+						}
+					}
+				}],
+				"Model": [{
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"type": "Text",
+					"maxLength": 256,
+					"displayAs": "pxTextInput",
+					"label": "model"
+				}],
+				"Brand": [{
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"type": "Text",
+					"maxLength": 256,
+					"displayAs": "pxTextInput",
+					"label": "brand"
+				}]
+			}
+		},
+		"components": ["DefaultForm", "Currency", "Dropdown", "Region", "TextInput", "View", "DataReference"],
+		"localeReferences": ["OI1OYV-MARCO2-WORK-DATAREFERENCETEST!CASE!DATAREFERENCETEST"],
+		"root": {
+			"type": "reference",
+			"config": {
+				"type": "view",
+				"name": "Create",
+				"context": "caseInfo.content"
+			}
+		},
+		"context_data": {
+			"caseInfo": {
+				"content": {
+					"summary_of_when_conditions__": {},
+					"DataReferenceSingleCars": {
+						"summary_of_when_conditions__": {
+							"pyIsMobileApp": false
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/src/commonMain/composeResources/files/responses/dx/cases/DataRefSemanticLinkTest-POST.json
+++ b/test/src/commonMain/composeResources/files/responses/dx/cases/DataRefSemanticLinkTest-POST.json
@@ -1,0 +1,552 @@
+{
+	"data": {
+		"caseInfo": {
+			"caseTypeID": "OI1OYV-Marco2-Work-DataReferenceTest",
+			"owner": "user@marco",
+			"availableActions": [{
+				"name": "Edit details",
+				"links": {
+					"open": {
+						"rel": "self",
+						"href": "/cases/OI1OYV-MARCO2-WORK D-12038/actions/pyUpdateCaseDetails",
+						"type": "GET",
+						"title": "Get case action details"
+					}
+				},
+				"ID": "pyUpdateCaseDetails",
+				"type": "Case"
+			}, {
+				"name": "Change stage",
+				"links": {
+					"open": {
+						"rel": "self",
+						"href": "/cases/OI1OYV-MARCO2-WORK D-12038/actions/pyChangeStage",
+						"type": "GET",
+						"title": "Get case action details"
+					}
+				},
+				"ID": "pyChangeStage",
+				"type": "Case"
+			}],
+			"associations": {
+				"follows": false
+			},
+			"lastUpdatedBy": "user@marco",
+			"assignments": [{
+				"instructions": "",
+				"canPerform": "true",
+				"assigneeInfo": {
+					"name": "Administrator",
+					"ID": "user@marco",
+					"type": "worklist"
+				},
+				"processID": "CreateForm_Default",
+				"createTime": "2026-04-22T09:16:54.670Z",
+				"urgency": 10,
+				"processName": "Create",
+				"isMultiStep": "true",
+				"name": "Create",
+				"context": "",
+				"links": {
+					"open": {
+						"rel": "self",
+						"href": "/assignments/ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT",
+						"type": "GET",
+						"title": "Get assignment details"
+					}
+				},
+				"ID": "ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT",
+				"actions": [{
+					"name": "Create",
+					"links": {
+						"submit": {
+							"rel": "self",
+							"href": "/assignments/ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT/actions/Create",
+							"type": "PATCH",
+							"title": "Submit assignment action "
+						},
+						"save": {
+							"rel": "self",
+							"href": "/assignments/ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT/actions/Create/save",
+							"type": "PATCH",
+							"title": "Save assignment action "
+						},
+						"open": {
+							"rel": "self",
+							"href": "/assignments/ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT/actions/Create",
+							"type": "GET",
+							"title": "Get assignment action details"
+						}
+					},
+					"ID": "Create",
+					"type": "FlowAction"
+				}]
+			}],
+			"hasNewAttachments": false,
+			"businessID": "D-12038",
+			"sla": {
+				"goal": "",
+				"deadline": ""
+			},
+			"WidgetsToRefresh": ["TaskList"],
+			"caseTypeName": "DataReferenceTest",
+			"urgency": 10,
+			"createTime": "2026-04-22T09:16:54.661Z",
+			"createdBy": "user@marco",
+			"name": "DataReferenceTest",
+			"stages": [{
+				"entryTime": "2026-04-22T09:16:54.667Z",
+				"name": "Create",
+				"links": {
+					"open": {
+						"rel": "self",
+						"href": "/cases/OI1OYV-MARCO2-WORK D-12038/stages/PRIM0",
+						"type": "PUT",
+						"title": "Jump to this stage"
+					}
+				},
+				"visited_status": "active",
+				"ID": "PRIM0",
+				"type": "Primary",
+				"transitionType": "create"
+			}, {
+				"name": "stage2",
+				"links": {
+					"open": {
+						"rel": "self",
+						"href": "/cases/OI1OYV-MARCO2-WORK D-12038/stages/PRIM1",
+						"type": "PUT",
+						"title": "Jump to this stage"
+					}
+				},
+				"visited_status": "future",
+				"ID": "PRIM1",
+				"type": "Primary",
+				"transitionType": "manual"
+			}],
+			"ID": "OI1OYV-MARCO2-WORK D-12038",
+			"caseTypeIcon": "cmicons/pycase.svg",
+			"status": "New",
+			"stageID": "PRIM0",
+			"stageLabel": "Create",
+			"lastUpdateTime": "2026-04-22T09:16:54.672Z",
+			"content": {
+				"classID": "OI1OYV-Marco2-Work-DataReferenceTest",
+				"pxObjClass": "OI1OYV-Marco2-Work-DataReferenceTest",
+				"pyLabel": "DataReferenceTest",
+				"pyID": "D-12038",
+				"pyViewName": "Create",
+				"pyViewContext": "",
+				"DataReferenceSingleCars": {
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"pyGUID": "",
+					"Model": "",
+					"Brand": ""
+				}
+			}
+		}
+	},
+	"uiResources": {
+		"resources": {
+			"views": {
+				"pyEmbedAssignment": [{
+					"name": "pyEmbedAssignment",
+					"type": "View",
+					"config": {
+						"ruleClass": "Work-",
+						"localeReference": "@LR WORK-!VIEW!PYEMBEDASSIGNMENT"
+					},
+					"children": [{
+						"name": "A",
+						"type": "Region",
+						"children": [{
+							"type": "reference",
+							"config": {
+								"type": "view",
+								"name": "pyCaseWorkarea"
+							}
+						}]
+					}],
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest"
+				}],
+				"pyCaseWorkarea": [{
+					"name": "pyCaseWorkarea",
+					"type": "View",
+					"config": {
+						"ruleClass": "Work-",
+						"localeReference": "@LR WORK-!VIEW!PYCASEWORKAREA"
+					},
+					"children": [{
+						"name": "A",
+						"type": "Region",
+						"children": [{
+							"type": "reference",
+							"config": {
+								"type": "view",
+								"name": "pzFlowContainer"
+							}
+						}]
+					}],
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest"
+				}],
+				"pzFlowContainer": [{
+					"name": "pzFlowContainer",
+					"type": "View",
+					"config": {
+						"ruleClass": "@baseclass",
+						"localeReference": "@LR @BASECLASS!VIEW!PZFLOWCONTAINER"
+					},
+					"children": [{
+						"type": "FlowContainer",
+						"config": {
+							"name": "workarea",
+							"routingInfo": "@ROUTING_INFO"
+						},
+						"children": [{
+							"type": "reference",
+							"config": {
+								"type": "view",
+								"name": "@P .pyViewName",
+								"context": "@P .pyViewContext"
+							}
+						}]
+					}],
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest"
+				}],
+				"Create": [{
+					"children": [{
+						"children": [{
+							"config": {
+								"authorContext": ".DataReferenceSingleCars",
+								"inheritedProps": [{
+									"prop": "label",
+									"value": "@FL .DataReferenceSingleCars"
+								}],
+								"name": "Create_DataReferenceSingleCars",
+								"referenceType": "Data",
+								"ruleClass": "OI1OYV-Marco2-Work-DataReferenceTest",
+								"type": "view"
+							},
+							"type": "reference"
+						}],
+						"name": "Fields",
+						"type": "Region"
+					}],
+					"config": {
+						"NumCols": "2",
+						"localeReference": "@LR OI1OYV-MARCO2-WORK-DATAREFERENCETEST!VIEW!CREATE",
+						"ruleClass": "OI1OYV-Marco2-Work-DataReferenceTest",
+						"template": "DefaultForm"
+					},
+					"name": "Create",
+					"type": "View",
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest"
+				}],
+				"Create_DataReferenceSingleCars": [{
+					"children": [{
+						"config": {
+							"columns": [{
+								"key": "true",
+								"setProperty": "Associated property",
+								"value": ".pyGUID"
+							}, {
+								"display": "true",
+								"primary": "true",
+								"useForSearch": true,
+								"value": ".Model"
+							}],
+							"contextPage": "@P .DataReferenceSingleCars",
+							"datasource": "D_CarsList2",
+							"deferDatasource": true,
+							"label": "@L ",
+							"labelOption": "custom",
+							"listType": "datapage",
+							"placeholder": "@L Select...",
+							"primaryField": "@P .DataReferenceSingleCars.Model",
+							"value": "@P .DataReferenceSingleCars.pyGUID"
+						},
+						"type": "Dropdown"
+					}, {
+						"children": [{
+							"config": {
+								"context": ".DataReferenceSingleCars",
+								"inheritedProps": [{
+									"prop": "showLabel",
+									"value": true
+								}, {
+									"prop": "label",
+									"value": "@L Create - EmbeddedDataCarSingle"
+								}],
+								"name": "Create_EmbeddedDataCarSingle",
+								"readOnly": true,
+								"ruleClass": "OI1OYV-Marco2-Data-Car",
+								"type": "view"
+							},
+							"type": "reference"
+						}],
+						"name": "Views",
+						"type": "Region"
+					}],
+					"config": {
+						"classKeys": [{
+							"name": "pyGUID"
+						}],
+						"contextClass": "OI1OYV-Marco2-Data-Car",
+						"displayAs": "dropdown",
+						"localeReference": "@LR OI1OYV-MARCO2-WORK-DATAREFERENCETEST!VIEW!CREATE_DATAREFERENCESINGLECARS",
+						"mode": "singleselect",
+						"name": "DataReferenceSingleCars",
+						"parameters": {
+							"brand": ""
+						},
+						"referenceList": "D_CarsList2",
+						"ruleClass": "OI1OYV-Marco2-Work-DataReferenceTest",
+						"selectionMode": "single",
+						"template": "DataReference"
+					},
+					"name": "Create_DataReferenceSingleCars",
+					"type": "View",
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest"
+				}],
+				"Create_EmbeddedDataCarSingle": [{
+					"children": [{
+						"children": [{
+							"config": {
+								"label": "@FL .Brand",
+								"labelOption": "default",
+								"value": "@P .Brand"
+							},
+							"type": "TextInput"
+						}, {
+							"config": {
+								"label": "@FL .Model",
+								"labelOption": "default",
+								"value": "@P .Model"
+							},
+							"type": "TextInput"
+						}, {
+							"config": {
+								"allowDecimals": true,
+								"alwaysShowISOCode": false,
+								"isoCodeSelection": "constant",
+								"label": "@FL .Price",
+								"labelOption": "default",
+								"value": "@P .Price",
+								"visibility": "@W pyIsMobileApp"
+							},
+							"type": "Currency"
+						}],
+						"name": "Fields",
+						"type": "Region"
+					}],
+					"config": {
+						"localeReference": "@LR OI1OYV-MARCO2-DATA-CAR!VIEW!CREATE_EMBEDDEDDATACARSINGLE",
+						"mode": "editable",
+						"ruleClass": "OI1OYV-Marco2-Data-Car",
+						"template": "DefaultForm"
+					},
+					"name": "Create_EmbeddedDataCarSingle",
+					"type": "View",
+					"classID": "OI1OYV-Marco2-Data-Car"
+				}]
+			},
+			"datapages": {
+				"D_car": {
+					"parameters": [{
+						"name": "pyGUID",
+						"defaultValue": "",
+						"linkedField": "pyGUID"
+					}],
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"mode": "readonly",
+					"isSearchable": false,
+					"isQueryable": false,
+					"isAlternateKeyStorage": true,
+					"structure": "page"
+				},
+				"D_CarsList2": {
+					"parameters": [{
+						"name": "brand",
+						"defaultValue": ""
+					}],
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"mode": "readonly",
+					"isSearchable": false,
+					"isQueryable": true,
+					"structure": "list",
+					"isWorkObject": false,
+					"isDataObject": true
+				},
+				"D_carSavable": {
+					"parameters": [{
+						"name": "pyGUID",
+						"defaultValue": "",
+						"linkedField": "pyGUID"
+					}],
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"mode": "editable",
+					"isSearchable": false,
+					"isQueryable": false,
+					"isAlternateKeyStorage": true,
+					"structure": "page"
+				}
+			},
+			"dataTypes": {
+				"OI1OYV-Marco2-Data-Car": {
+					"classKeys": ["pyGUID"],
+					"savableDataPage": "D_carSavable",
+					"lookupDataPage": "D_car",
+					"lookupDataPageInfo": {
+						"isAlternateKeyStorage": true,
+						"parameters": {
+							"pyGUID": "@P .pyGUID"
+						}
+					}
+				}
+			},
+			"fields": {
+				"pyLabel": [{
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest",
+					"type": "Text",
+					"maxLength": 64,
+					"displayAs": "pxTextInput",
+					"definedOnClassID": "Work-",
+					"expectedLength": 60,
+					"label": "Label"
+				}],
+				"pyID": [{
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest",
+					"type": "Text",
+					"maxLength": 32,
+					"displayAs": "pxDisplayText",
+					"definedOnClassID": "Work-Cover-",
+					"expectedLength": 22,
+					"label": "Case ID",
+					"isClassKey": true
+				}],
+				"pyViewName": [{
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest",
+					"type": "Text",
+					"displayAs": "pxTextInput",
+					"definedOnClassID": "Work-",
+					"label": "pyViewName"
+				}],
+				"pyViewContext": [{
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest",
+					"type": "Text",
+					"displayAs": "pxTextInput",
+					"definedOnClassID": "Work-",
+					"label": "pyViewContext"
+				}],
+				"pyGUID": [{
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"type": "Text",
+					"maxLength": 128,
+					"displayAs": "pxTextInput",
+					"definedOnClassID": "@baseclass",
+					"label": "Globally unique ID",
+					"isClassKey": true
+				}],
+				"DataReferenceSingleCars": [{
+					"classID": "OI1OYV-Marco2-Work-DataReferenceTest",
+					"type": "Page",
+					"dataRetrievalType": "refer",
+					"pageClass": "OI1OYV-Marco2-Data-Car",
+					"label": "DataReferenceSingleCars",
+					"datasource": {
+						"name": "D_car",
+						"parameters": {
+							"pyGUID": "@P .DataReferenceSingleCars.pyGUID"
+						}
+					}
+				}],
+				"Model": [{
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"type": "Text",
+					"maxLength": 256,
+					"displayAs": "pxTextInput",
+					"label": "model"
+				}],
+				"Brand": [{
+					"classID": "OI1OYV-Marco2-Data-Car",
+					"type": "Text",
+					"maxLength": 256,
+					"displayAs": "pxTextInput",
+					"label": "brand"
+				}]
+			}
+		},
+		"components": ["DefaultForm", "FlowContainer", "Currency", "Dropdown", "Region", "TextInput", "View", "DataReference"],
+		"localeReferences": ["OI1OYV-MARCO2-WORK-DATAREFERENCETEST!CASE!DATAREFERENCETEST"],
+		"root": {
+			"type": "reference",
+			"config": {
+				"type": "view",
+				"name": "pyEmbedAssignment",
+				"context": "caseInfo.content"
+			}
+		},
+		"context_data": {
+			"caseInfo": {
+				"content": {
+					"summary_of_when_conditions__": {},
+					"DataReferenceSingleCars": {
+						"summary_of_when_conditions__": {
+							"pyIsMobileApp": false
+						}
+					}
+				}
+			}
+		},
+		"navigation": {
+			"template": "Horizontal",
+			"steps": [{
+				"allow_jump": true,
+				"name": "Create",
+				"actionID": "Create",
+				"visited_status": "current",
+				"ID": "AssignmentSF1"
+			}, {
+				"allow_jump": true,
+				"name": "step2",
+				"actionID": "Step2_2",
+				"visited_status": "future",
+				"links": {
+					"open": {
+						"rel": "self",
+						"href": "assignments/ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT/navigation_steps/AssignmentSF2",
+						"type": "PATCH",
+						"title": "Go to step2"
+					}
+				},
+				"ID": "AssignmentSF2"
+			}]
+		},
+		"actionButtons": {
+			"secondary": [{
+				"jsAction": "cancelAssignment",
+				"name": "Cancel",
+				"actionID": "cancel"
+			}],
+			"main": [{
+				"jsAction": "finishAssignment",
+				"name": "Next   ",
+				"actionID": "next"
+			}]
+		}
+	},
+	"ID": "OI1OYV-MARCO2-WORK D-12038",
+	"nextAssignmentInfo": {
+		"context": "self",
+		"className": "OI1OYV-Marco2-Work-DataReferenceTest",
+		"links": {
+			"open": {
+				"rel": "self",
+				"href": "/assignments/ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT",
+				"type": "GET",
+				"title": "Get assignment details"
+			}
+		},
+		"ID": "ASSIGN-WORKLIST OI1OYV-MARCO2-WORK D-12038!CREATEFORM_DEFAULT"
+	}
+}

--- a/test/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/test/mock/handlers/DxAssignmentsHandler.kt
+++ b/test/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/test/mock/handlers/DxAssignmentsHandler.kt
@@ -36,6 +36,7 @@ class DxAssignmentsHandler : MockHandler {
             assignmentId.contains("D-7004") -> handleDataReferenceListOfRecordsTest(actionId)
             assignmentId.contains("D-17009") -> handleDataReferenceMultiSelectTest(request, actionId)
             assignmentId.contains("D-9001") -> handleDetailsTemplateTest(actionId)
+            assignmentId.contains("D-12038") -> handleDataRefSemanticLinkTest(actionId)
 
             else -> Error(501, "Cannot handle assignment: $assignmentId, action: $actionId")
         }
@@ -132,6 +133,12 @@ class DxAssignmentsHandler : MockHandler {
 
     private fun handleDetailsTemplateTest(actionId: String) = when (actionId) {
         "DetailsTemplate2" -> Asset("responses/dx/assignments/DetailsTemplateTest.json")
+        else -> Error(404, "Invalid actionId: $actionId")
+    }
+
+    private fun handleDataRefSemanticLinkTest(actionId: String) = when (actionId) {
+        "Create" -> Asset("responses/dx/assignments/DataRefSemanticLinkTest-1-Create.json")
+        "Create/refresh" -> Asset("responses/dx/assignments/refresh/DataRefSemanticLinkTest-Create-Refresh.json")
         else -> Error(404, "Invalid actionId: $actionId")
     }
 

--- a/test/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/test/mock/handlers/DxCasesHandler.kt
+++ b/test/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/test/mock/handlers/DxCasesHandler.kt
@@ -40,6 +40,7 @@ class DxCasesHandler : MockHandler {
             "OI1OYV-Marco2-Work-DetailsTemplateTest" -> Asset("responses/dx/cases/DetailsTest-POST.json")
             "OFV0MW-Marco-Work-EmbeddedDataTest-SingleRecord" -> Asset("responses/dx/cases/EmbeddedDataTest-SingleRecord.json")
             "OFV0MW-Marco-Work-EmbeddedDataTest-Combobox" -> Asset("responses/dx/cases/EmbeddedDataTest-Combobox-POST.json")
+            "OI1OYV-Marco2-Work-DataReferenceTest-FieldOnly" -> Asset("responses/dx/cases/DataRefSemanticLinkTest-POST.json")
             else -> Error(500, "Missing response for case $caseTypeId")
         }
     }

--- a/ui-renderer-cmp/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/ui/renderer/cmp/ComponentRenderers.kt
+++ b/ui-renderer-cmp/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/ui/renderer/cmp/ComponentRenderers.kt
@@ -31,6 +31,7 @@ import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.Region
 import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.RichText
 import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.RootContainer
 import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.SimpleComboBox
+import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.SemanticLink
 import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.SimpleTable
 import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.SimpleTableManual
 import com.pega.constellation.sdk.kmp.core.components.ComponentTypes.SimpleTableSelect
@@ -74,6 +75,7 @@ import com.pega.constellation.sdk.kmp.ui.renderer.cmp.fields.PhoneRenderer
 import com.pega.constellation.sdk.kmp.ui.renderer.cmp.fields.RadioButtonsRenderer
 import com.pega.constellation.sdk.kmp.ui.renderer.cmp.fields.RichTextRenderer
 import com.pega.constellation.sdk.kmp.ui.renderer.cmp.fields.SimpleComboBoxRenderer
+import com.pega.constellation.sdk.kmp.ui.renderer.cmp.fields.SemanticLinkRenderer
 import com.pega.constellation.sdk.kmp.ui.renderer.cmp.fields.TextAreaRenderer
 import com.pega.constellation.sdk.kmp.ui.renderer.cmp.fields.TextInputRenderer
 import com.pega.constellation.sdk.kmp.ui.renderer.cmp.fields.TimeRenderer
@@ -122,6 +124,7 @@ object ComponentRenderers {
         RootContainer to RootContainerRenderer(),
         RichText to RichTextRenderer(),
         SimpleComboBox to SimpleComboBoxRenderer(),
+        SemanticLink to SemanticLinkRenderer(),
         SimpleTable to SimpleTableRenderer(),
         SimpleTableManual to SimpleTableManualRenderer(),
         SimpleTableSelect to SimpleTableSelectRenderer(),

--- a/ui-renderer-cmp/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/ui/renderer/cmp/fields/SemanticLinkRenderer.kt
+++ b/ui-renderer-cmp/src/commonMain/kotlin/com/pega/constellation/sdk/kmp/ui/renderer/cmp/fields/SemanticLinkRenderer.kt
@@ -1,0 +1,16 @@
+package com.pega.constellation.sdk.kmp.ui.renderer.cmp.fields
+
+import androidx.compose.runtime.Composable
+import com.pega.constellation.sdk.kmp.core.components.fields.SemanticLinkComponent
+import com.pega.constellation.sdk.kmp.ui.components.cmp.controls.form.FieldValue
+import com.pega.constellation.sdk.kmp.ui.renderer.cmp.ComponentRenderer
+import com.pega.constellation.sdk.kmp.ui.renderer.cmp.helpers.WithVisibility
+
+class SemanticLinkRenderer : ComponentRenderer<SemanticLinkComponent> {
+    @Composable
+    override fun SemanticLinkComponent.Render() {
+        WithVisibility(visible) {
+            FieldValue(label, value)
+        }
+    }
+}


### PR DESCRIPTION
Add SemanticLink as a display-only field component across JS bridge, core, and renderer layers. Fix DataReference duplicate refresh issue by skipping manual refreshCaseView for picklist-based children (Dropdown, AutoComplete, Checkbox). Add instrumented UI test covering DataReference selection, refresh, and SemanticLink rendering after step transition.